### PR TITLE
アプリリリース用の更新

### DIFF
--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -7,7 +7,7 @@
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:960755529377:android:dd26696416b4ebbcab62e0",
+        "mobilesdk_app_id": "1:960755529377:android:c1545f3a5dbd3716ab62e0",
         "android_client_info": {
           "package_name": "com.aplus.tsukuba2023"
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+2
+version: 1.0.1+1
 
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION
1. version番号の更新
2. Android向けＦＣＭ設定の修正
　今までなんで動いていたのかわからないので直したほうが良いと思った．修正後にも通知を受け取れることを確認済み