### PR TITLE
AppLinks (Android) / Universal Links (iOS) の実装 

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -30,7 +30,8 @@ if (flutterVersionName == null) {
 
 android {
     namespace "com.aplus.tsukuba2023"
-    compileSdkVersion flutter.compileSdkVersion
+    //compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion 34 // The plugin url_launcher_android requires Android SDK version 34.
     ndkVersion flutter.ndkVersion
 
     signingConfigs {
@@ -61,7 +62,8 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion 21
-        targetSdkVersion flutter.targetSdkVersion
+        //targetSdkVersion flutter.targetSdkVersion
+        targetSdkVersion 34 // 毎年更新する必要がある
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -35,6 +35,15 @@ android:resource="@drawable/aplus_tsukuba_kari_icon" />
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <!-- Accepts URIs that begin with https://YOUR_HOST -->
+                <data
+                android:scheme="https"
+                android:host="www.aplus-tsukuba.net" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>FlutterDeepLinkingEnabled</key>
+	<true/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -7,8 +7,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:www.aplus-tsukuba.net</string>
-		<string>applinks:83b4-106-185-155-20.ngrok-free.app</string>
-		<string>webcredentials:83b4-106-185-155-20.ngrok-free.app</string>
+		<string>webcredentials:www.aplus-tsukuba.net</string>
 	</array>
 </dict>
 </plist>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -4,5 +4,11 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:www.aplus-tsukuba.net</string>
+		<string>applinks:83b4-106-185-155-20.ngrok-free.app</string>
+		<string>webcredentials:83b4-106-185-155-20.ngrok-free.app</string>
+	</array>
 </dict>
 </plist>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'dart:convert';
 import 'package:fluttertoast/fluttertoast.dart';
+import 'package:app_links/app_links.dart';
 
 final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
     FlutterLocalNotificationsPlugin();
@@ -255,6 +256,15 @@ class _WebViewAppState extends State<WebViewApp> {
       ..loadRequest(
         Uri.parse(aplusUrl),
       );
+
+    // AppLinks : https://pub.dev/packages/app_links
+    final _appLinks = AppLinks();
+    // Subscribe to all events when app is started.
+    // (Use allStringLinkStream to get it as [String])
+    _appLinks.allUriLinkStream.listen((uri) {
+      // Do something (navigation, ...)
+      controller.loadRequest(uri);
+    });
 
     FirebaseMessaging.onMessage.listen((RemoteMessage message) {
       final notification = message.notification;

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <gtk/gtk_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) gtk_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
+  gtk_plugin_register_with_registrar(gtk_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  gtk
   url_launcher_linux
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import app_links
 import firebase_analytics
 import firebase_core
 import firebase_messaging
@@ -13,6 +14,7 @@ import shared_preferences_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   FLTFirebaseAnalyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAnalyticsPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.22"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: "0fd41f0501f131d931251e0942ac63d6216096a0052aeca037915c2c1deeb121"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
   archive:
     dependency: transitive
     description:
@@ -264,6 +272,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.2.4"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: e8ce9ca4b1df106e4d72dad201d345ea1a036cc12c360f1a7d5a758f78ffa42c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   http:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.1+3
+version: 1.0.2+0
 
 environment:
   sdk: '>=3.2.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   firebase_analytics: ^10.7.2
   flutter_local_notifications: ^16.2.0
   flutter_launcher_icons: ^0.13.1
+  app_links: ^5.0.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.2+4
+version: 1.0.3+5
 
 environment:
   sdk: '>=3.2.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.2+0
+version: 1.0.2+4
 
 environment:
   sdk: '>=3.2.0 <4.0.0'

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,10 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <app_links/app_links_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  AppLinksPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  app_links
   firebase_core
   url_launcher_windows
 )


### PR DESCRIPTION
#33 のリベンジ special thanks : @ssf2xguile 

`app_links` ライブラリを使って簡単に実装している : https://pub.dev/packages/app_links

AndroidにおけるAppLinksのみ実装した．iOSは何もやっていないがmain.dartは共通で動作するはず．

iOSの作業手順
1. https://github.com/half-blue/A_plus_Tsukuba/pull/150 にiOS用ファイルを追加
2. Xcodeからドメインを追加する？ : https://developer.apple.com/documentation/safariservices/supporting_associated_domains

ngrokを使って動作確認済み

なお，ngrokを使わず，アプリ側のみテストすることもできる

1. Androidの場合は，設定アプリでA+つくばのアプリを開き，「デフォルトで開く」で対象ドメインを手動で有効にする（assetlinks.jsonの検証をしない場合は，セキュリティ対策でデフォルトで無効になっている）
2. PCからコマンドを実行 

Android : `adb shell am start -a android.intent.action.VIEW  -d "https://www.aplus-tsukuba.net/about/"`

iOS : `/usr/bin/xcrun simctl openurl booted  "https://www.aplus-tsukuba.net/about/"` （試してないけど）

アプリが起動し，意図した画面が表示されれば成功．

余談：
 - Discordからリンクを踏んでもブラウザが起動するので注意（仕様っぽい，Xとかはいけた）
 - ITFチェック未実施でリンクを踏むと，対象のページが表示される前にITFチェックが入り，その後対象ページに遷移する実装となっている．

@nitoca 暇ならiosやってみてほしい