### PR TITLE
ターゲットAPIレベルを34に変更する

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -30,7 +30,8 @@ if (flutterVersionName == null) {
 
 android {
     namespace "com.aplus.tsukuba2023"
-    compileSdkVersion flutter.compileSdkVersion
+    //compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion 34 // The plugin url_launcher_android requires Android SDK version 34.
     ndkVersion flutter.ndkVersion
 
     signingConfigs {
@@ -61,7 +62,8 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion 21
-        targetSdkVersion flutter.targetSdkVersion
+        //targetSdkVersion flutter.targetSdkVersion
+        targetSdkVersion 34 // 毎年更新する必要がある
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.1+3
+version: 1.0.2+0
 
 environment:
   sdk: '>=3.2.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.2+0
+version: 1.0.2+4
 
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION
Google Playのポリシーに準拠するため，ターゲットAPIレベルを34に変更します
https://support.google.com/googleplay/android-developer/answer/11926878

Android14を搭載したスマホでチェックしましたが，通知機能含めて正常に動作しているように見えます．

ビルドするためには以下の操作が必要かもです．
1 . `flutter clean`
2. `flutter pub get`

Google Playの内部テストにappBundleをuploadして，エラーがでないことを確認しています．
そのため，バージョン番号とバージョンコード`prospec.yaml`も変更しています．

このPRを即時リリースする場合はバージョンコードをインクリメントする必要があります．