### PR TITLE
ネットが遅い場合に、不適切なボタンが表示され続けてしまう問題を修正

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -230,8 +230,7 @@ class _WebViewAppState extends State<WebViewApp> {
           onProgress: (int progress) {
             // Update loading bar.
           },
-          onPageStarted: (String url) {},
-          onPageFinished: (String url) {
+          onPageStarted: (String url) {
             setState(() {
               currentUrl = url;
               showButton =
@@ -239,6 +238,7 @@ class _WebViewAppState extends State<WebViewApp> {
               showNoticeManagementButton = currentUrl.contains("search");
             });
           },
+          onPageFinished: (String url) {},
           onWebResourceError: (WebResourceError error) {},
           onNavigationRequest: (NavigationRequest request) async {
             if (request.url.startsWith(aplusUrl)) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -238,7 +238,14 @@ class _WebViewAppState extends State<WebViewApp> {
               showNoticeManagementButton = currentUrl.contains("search");
             });
           },
-          onPageFinished: (String url) {},
+          onPageFinished: (String url) {
+            setState(() {
+              currentUrl = url;
+              showButton =
+                  currentUrl.contains("threads"); // URLに'threads'が含まれているかチェック
+              showNoticeManagementButton = currentUrl.contains("search");
+            });
+          },
           onWebResourceError: (WebResourceError error) {},
           onNavigationRequest: (NavigationRequest request) async {
             if (request.url.startsWith(aplusUrl)) {


### PR DESCRIPTION
ページ読み込み完了時ではなく、開始時にボタンの切り替えを行う。

新しい設定でも問題が起きることがあるが、こちらの方がましな挙動になる。