### PR TITLE
Android 15 (APIレベル35）への対応

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -31,8 +31,8 @@ if (flutterVersionName == null) {
 android {
     namespace "com.aplus.tsukuba2023"
     //compileSdkVersion flutter.compileSdkVersion
-    compileSdkVersion 34 // The plugin url_launcher_android requires Android SDK version 34.
-    ndkVersion flutter.ndkVersion
+    compileSdkVersion 35 // The plugin url_launcher_android requires Android SDK version 35. (毎年更新)
+    ndkVersion android.ndkVersion
 
     signingConfigs {
        release {
@@ -46,6 +46,7 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+        coreLibraryDesugaringEnabled true // Flag to enable support for the new language APIs
     }
 
     kotlinOptions {
@@ -63,7 +64,7 @@ android {
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion 21
         //targetSdkVersion flutter.targetSdkVersion
-        targetSdkVersion 34 // 毎年更新する必要がある
+        targetSdkVersion 35 // 毎年更新する必要がある
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }
@@ -80,4 +81,6 @@ flutter {
     source '../..'
 }
 
-dependencies {}
+dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3' // For AGP 7.4+
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,11 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '2.1.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
+        classpath "com.android.tools.build:gradle:8.3.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
+android.ndkVersion=27.0.12077973

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -23,7 +23,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
+    id "com.android.application" version "8.7.3" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -361,7 +361,8 @@ class _WebViewAppState extends State<WebViewApp> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: const EmptyAppBar(),
-      body: Stack(
+      body: SafeArea(
+        child: Stack(
         children: <Widget>[
           WebViewWidget(
             controller: controller,
@@ -570,7 +571,7 @@ class _WebViewAppState extends State<WebViewApp> {
             ),
         ],
       ),
-    );
+    ));
   }
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -361,8 +361,12 @@ class _WebViewAppState extends State<WebViewApp> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: const EmptyAppBar(),
-      body: SafeArea(
-        child: Stack(
+      body: Platform.isAndroid ? SafeArea(child: getAppBody()) : getAppBody(),
+    );
+  }
+
+  Widget getAppBody() {
+    return Stack(
         children: <Widget>[
           WebViewWidget(
             controller: controller,
@@ -570,8 +574,7 @@ class _WebViewAppState extends State<WebViewApp> {
                   }),
             ),
         ],
-      ),
-    ));
+    );
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.0+6
+version: 1.1.1+7
 
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION
# 問題の概要
<img width="957" height="323" alt="image" src="https://github.com/user-attachments/assets/a3005b72-d375-4e02-af9d-2a7eda9bf7cf" />
Android 15 (APIレベル35）に対応するようにアプリを更新する必要がある

## 1. APIレベルの変更
`android`フォルダ以下の設定をいろいろ変更し、Android15に対応するように変更。
gradleやandroidNdkなどの依存関係をアップデートする必要があった（かなりめんどくさかった）

cf.
https://stackoverflow.com/questions/78678063/android-15-update-compilesdk-android-35-cause-an-error-res-table-type-type-e
https://midland.hatenadiary.jp/entry/2025/06/12/153221

## 2. `Edge-to-Edge`への対応
Android 15からは`Edge-to-Edge`がデフォルトになる。
https://docs.flutter.dev/release/breaking-changes/default-systemuimode-edge-to-edge
これはアプリが画面全体を使用するようになる（大変余計なお世話な）機能。

A+つくばでは以下のような影響がある。
・現在リリースされているアプリでの表示
<img width="381" height="137" alt="image" src="https://github.com/user-attachments/assets/e8e52e05-5eac-4350-b319-62c9f29c6517" />
・APIレベルを変更した場合の表示
<img width="387" height="101" alt="image" src="https://github.com/user-attachments/assets/69314641-cc7b-46b1-9f31-b630ec4d5fd2" />
**アプリが画面端まで拡張され、ボタンが隠れてしまう**

そこで、`main.dart`を変更し、アプリに`SafeArea`を設定して、この問題を回避する。
・SafeArea適用後
<img width="384" height="132" alt="image" src="https://github.com/user-attachments/assets/dbb28d8c-5f88-4df3-ac85-64b911b30b29" />

## レビューしてほしいこと
`SafeArea`の適用がiOSに影響を及ぼさないか